### PR TITLE
Add `rime-agda-input`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,4 +282,5 @@ rime 輸入方案和配置列表
 - **5** [sgalal/rime-opencc-latest](https://github.com/sgalal/rime-opencc-latest) - Customize rime input schemata to use the latest OpenCC dictionaries
 - **5** [sgalal/rime-symbolic-simp](https://github.com/sgalal/rime-symbolic-simp) - Symbolic input for rime (Simplified Chinese version) | rime 符號輸入（简化字版）
 - **4** [sgalal/rime-symbolic](https://github.com/sgalal/rime-symbolic) - Symbolic input for Rime | Rime 符號輸入
+- **3** [Godalin/rime-agda-input](https://github.com/Godalin/rime-agda-input) - Rime Agda Input | `agda-input.el` 符號輸入，更短的數學符號方案。提供了與 `rime-latex` 兼容的配置案例
 - **0** [sgalal/rime-opencc-32bit-latest](https://github.com/sgalal/rime-opencc-32bit-latest) - Customize rime input schemata to use the latest OpenCC dictionaries (32-bit)


### PR DESCRIPTION
[`rime-agda-input`](https://github.com/Godalin/rime-agda-input) 提供了一種比 `rime-latex` 更加短小簡潔的數學符號輸入方案，靈感來源於交互式定理證明器 Agda 在 Emacs 中的輸入方案 [`agda-input.el`](https://github.com/agda/agda/blob/master/src/data/emacs-mode/agda-input.el)。希望可以在 rime-awesome 頁面得到宣傳 😄️

舉例：

"\Gl" ⇒ "λ"
"\l" ⇒ "←"

等等。